### PR TITLE
Initialize fields and nested from KProperty and infer views and optionnality

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     val spekVersion = "2.0.5"
     val assertJVersion = "3.11.1"
     compile(kotlin("stdlib-jdk8"))
+    compile(kotlin("reflect"))
     compile("org.springframework.restdocs:spring-restdocs-core:$springRestDocsVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
@@ -123,5 +124,5 @@ signing {
 
 buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    setTermsOfServiceAgree("yes")
+    termsOfServiceAgree = "yes"
 }

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Aliases.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Aliases.kt
@@ -3,4 +3,4 @@ package com.github.jntakpe.restdocs.dsl
 import kotlin.reflect.KClass
 
 typealias View = KClass<*>
-typealias Views = MutableSet<KClass<*>>
+typealias Views = MutableSet<View>

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Delegates.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Delegates.kt
@@ -1,0 +1,37 @@
+package com.github.jntakpe.restdocs.dsl
+
+import com.github.jntakpe.restdocs.dsl.JsonDescriptor.list
+import com.github.jntakpe.restdocs.dsl.JsonDescriptor.root
+import org.springframework.restdocs.payload.FieldDescriptor
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+/**
+ * Property delegates for initializing an object description in a val.
+ * Use it like val petDoc by obj { field(Pet:: ...) }
+ */
+fun obj(init: Root.() -> Unit) = ObjectDoc(init)
+
+class ObjectDoc(private val init: Root.() -> Unit) {
+    operator fun getValue(thisRef: Any?, property: KProperty<*>) = root(init)
+}
+
+/**
+ * Property delegates for initializing an array of objects description in a val providing a description
+ * Use it like val petsDoc by arrDesc(petDesc, "Array of pets")
+ */
+fun arrDesc(of: MutableList<FieldDescriptor>, description: String) = ListDoc(description, of)
+
+/**
+ * Property delegates for initializing an array of objects description in a val.
+ * Unlike [arrDesc], description in inferred from given Type [T].
+ * Use it like val petsDoc by arr<Pet>(petDesc)
+ */
+inline fun <reified T> arr(of: MutableList<FieldDescriptor>, description: String = "Array of ${T::class.toPluralName()}") = ListDoc(description, of)
+
+class ListDoc(private val description: String, private val of: MutableList<FieldDescriptor>) {
+    operator fun getValue(thisRef: Any?, property: KProperty<*>) = list(description) { fields += of }
+}
+
+// TODO improve, maybe with a third party
+fun KClass<*>.toPluralName() = "${simpleName?.toLowerCase().orEmpty()}s"

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Field.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Field.kt
@@ -7,7 +7,7 @@ import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 /**
  * Represent a simple field used to document non-nested fields
  */
-internal interface Field {
+interface Field {
 
     companion object {
         const val VIEWS_ATTR = "jsonViews"

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/FieldsExtension.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/FieldsExtension.kt
@@ -1,0 +1,17 @@
+package com.github.jntakpe.restdocs.dsl
+
+import org.springframework.restdocs.payload.FieldDescriptor
+import kotlin.reflect.KProperty
+
+/**
+ * Like [Nested.field] but enforce type in case a Jackson (De)Serializer is used
+ * @param T actual type of the property once (de)serialized
+ */
+inline fun <reified T> Nested.field(
+    property: KProperty<*>,
+    description: String,
+    of: MutableList<FieldDescriptor>? = null,
+    noinline block: (Nested.() -> Unit)? = null
+) : Field {
+    return fieldOf(T::class, property, description, of, block)
+}

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/JsonDescriptor.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/JsonDescriptor.kt
@@ -10,12 +10,12 @@ object JsonDescriptor {
      * @param init function with [Root] receiver used to document JSON object fields
      * @return documented fields
      */
-    fun root(init: Root.() -> Unit) = Root().apply { init() }.fields
+    fun root(init: Root.() -> Unit) = Root().apply(init).fields
 
     /**
      * Creates a new JSON array documentation list of fields
      * @param init function with [Root] receiver used to document JSON array fields
      * @return documented fields
      */
-    fun list(description: String, init: RootList.() -> Unit) = RootList(description).apply { init() }.fields
+    fun list(description: String, init: RootList.() -> Unit) = RootList(description).apply(init).fields
 }

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Nested.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/Nested.kt
@@ -1,8 +1,16 @@
 package com.github.jntakpe.restdocs.dsl
 
+import com.fasterxml.jackson.annotation.JsonView
 import com.github.jntakpe.restdocs.dsl.Field.Companion.VIEWS_ATTR
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import kotlin.reflect.KClass
+import kotlin.reflect.KClassifier
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
+
+typealias ArrayBlock = Array.() -> Unit
+typealias JsonBlock = Json.() -> Unit
 
 /**
  * Represent nested field like a JSON object or an array
@@ -22,7 +30,7 @@ abstract class Nested(private val basePath: String, private val views: Views = m
         description: String,
         vararg view: View,
         optional: Boolean = false,
-        block: Array.() -> Unit
+        block: ArrayBlock
     ): Array {
         return nested(
             Array(name, description, view.toMutableSet().apply { addAll(views) }, optional, arrayPath(name)),
@@ -30,20 +38,92 @@ abstract class Nested(private val basePath: String, private val views: Views = m
         )
     }
 
+    fun array(
+        property: KProperty<*>,
+        description: String,
+        of: MutableList<FieldDescriptor>? = null,
+        block: ArrayBlock? = null
+    ): Array {
+        // Looks ugly but functions literals are a mess to cast
+        val b: ArrayBlock? = block ?: if (of != null) {
+            { fields += of!! }
+        } else {
+            null as? ArrayBlock
+        }
+        return b?.let {
+            property.run { array(name, description, *viewsArray(), optional = isOptional(), block = it) }
+        } ?: property.run { array(name, description, *viewsArray(), optional = isOptional()) }
+    }
+
     fun boolean(name: String, description: String, vararg view: View, optional: Boolean = false): Bool {
         return field(Bool(name, description, view.toMutableSet().apply { addAll(views) }, optional))
     }
 
-    fun nil(name: String, description: String, vararg view: View, optional: Boolean = false): Nil {
-        return field(Nil(name, description, view.toMutableSet().apply { addAll(views) }, optional))
+    fun boolean(property: KProperty<*>, description: String): Bool {
+        return property.run { boolean(name, description, *viewsArray(), optional = isOptional()) }
+    }
+
+    fun nil(name: String, description: String, vararg view: View): Nil {
+        return field(Nil(name, description, view.toMutableSet().apply { addAll(views) }, false))
+    }
+
+    fun nil(property: KProperty<Any?>, description: String): Nil {
+        return property.run { nil(name, description, *viewsArray()) }
     }
 
     fun number(name: String, description: String, vararg view: View, optional: Boolean = false): Number {
         return field(Number(name, description, view.toMutableSet().apply { addAll(views) }, optional))
     }
 
+    fun number(property: KProperty<*>, description: String): Number {
+        return property.run { number(name, description, *viewsArray(), optional = isOptional()) }
+    }
+
     fun string(name: String, description: String, vararg view: View, optional: Boolean = false): Text {
         return field(Text(name, description, view.toMutableSet().apply { addAll(views) }, optional))
+    }
+
+    fun string(property: KProperty<*>, description: String): Text {
+        return property.run { string(name, description, *viewsArray(), optional = isOptional()) }
+    }
+
+    /**
+     * Documents any object's field.
+     * Does type inference on [property] return type
+     * so you can use it for any kind of field (primitive, json, array of primitive/json)
+     * except for always null fields (use [nil] in this case).
+     * Infers [JsonView] and nullability.
+     * @param property a [KProperty] like Pet::nickname
+     * @param description description of the field
+     * @param of a nullable object description in case of json or array of json
+     * like field(Pet::store, "Pet's store", storeDesc)
+     * @param block a nullable function literal with self as receiver for appending descriptions to self
+     * like field(Pet::store, "Pet's store") { fields += storeDesc }. Has precedence over [of]
+     */
+    fun field(
+        property: KProperty<*>,
+        description: String,
+        of: MutableList<FieldDescriptor>? = null,
+        block: (Nested.() -> Unit)? = null
+    ): Field {
+        return fieldOf(property.returnType.classifier, property, description, of, block)
+    }
+
+    fun fieldOf(
+        type: KClassifier?,
+        property: KProperty<*>,
+        description: String,
+        of: MutableList<FieldDescriptor>? = null,
+        block: (Nested.() -> Unit)? = null
+    ): Field {
+        return when (type) {
+            String::class, Byte::class, ByteArray::class -> string(property, description)
+            Boolean::class -> boolean(property, description)
+            Short::class, Int::class, Long::class, Float::class, Double::class -> number(property, description)
+            Any::class, JvmType.Object::class -> varies(property, description)
+            Collection::class, List::class, Set::class -> array(property, description, of, block)
+            else -> json(property, description, of, block as? Json.() -> Unit)
+        }
     }
 
     fun json(
@@ -51,7 +131,7 @@ abstract class Nested(private val basePath: String, private val views: Views = m
         description: String,
         vararg view: View,
         optional: Boolean = false,
-        block: Json.() -> Unit
+        block: JsonBlock
     ): Json {
         return nested(
             Json(name, description, view.toMutableSet().apply { addAll(views) }, optional, "$basePath$name."),
@@ -59,8 +139,27 @@ abstract class Nested(private val basePath: String, private val views: Views = m
         )
     }
 
+    fun json(
+        property: KProperty<*>,
+        description: String,
+        of: MutableList<FieldDescriptor>? = null,
+        block: JsonBlock? = null
+    ): Json {
+        // Looks ugly but functions literals are a mess to cast
+        val b: JsonBlock = block ?: if (of != null) {
+            { fields += of!! }
+        } else {
+            {} as JsonBlock
+        }
+        return property.run { json(name, description, *viewsArray(), optional = isOptional(), block = b) }
+    }
+
     fun varies(name: String, description: String, vararg view: View, optional: Boolean = false): Varies {
         return field(Varies(name, description, view.toMutableSet().apply { addAll(views) }, optional))
+    }
+
+    fun varies(property: KProperty<Any?>, description: String): Varies {
+        return property.run { varies(name, description, *viewsArray(), optional = isOptional()) }
     }
 
     operator fun MutableCollection<in FieldDescriptor>.plusAssign(elements: Iterable<FieldDescriptor>) {

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/PayloadExtensions.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/PayloadExtensions.kt
@@ -1,0 +1,21 @@
+package com.github.jntakpe.restdocs.dsl
+
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.payload.RequestFieldsSnippet
+import org.springframework.restdocs.payload.ResponseFieldsSnippet
+
+/**
+ * Transform a [List] of [FieldDescriptor] into a [RequestFieldsSnippet]
+ * @receiver any [List] of [FieldDescriptor]
+ * @return a [RequestFieldsSnippet]
+ */
+fun MutableList<FieldDescriptor>.asReq(): RequestFieldsSnippet = requestFields(this)
+
+/**
+ * Transform a [List] of [FieldDescriptor] into a [ResponseFieldsSnippet]
+ * @receiver any [List] of [FieldDescriptor]
+ * @return a [ResponseFieldsSnippet]
+ */
+fun MutableList<FieldDescriptor>.asResp(): ResponseFieldsSnippet = responseFields(this)

--- a/src/main/kotlin/com/github/jntakpe/restdocs/dsl/PropertyExtensions.kt
+++ b/src/main/kotlin/com/github/jntakpe/restdocs/dsl/PropertyExtensions.kt
@@ -1,0 +1,28 @@
+package com.github.jntakpe.restdocs.dsl
+
+import com.fasterxml.jackson.annotation.JsonView
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.javaField
+
+fun KProperty<*>.isOptional(): Boolean = returnType.isMarkedNullable
+
+fun KProperty<*>.views(): Views = findAnnotations<JsonView>().flatMap { it.value.toList() }.toMutableSet()
+
+fun KProperty<*>.viewsArray(): kotlin.Array<View> = views().toTypedArray()
+
+inline fun <reified T : Annotation> KProperty<*>.findAnnotations(): kotlin.Array<out T> {
+    return (findFieldAnnotations<T>() + findGetterAnnotations() + findSetterAnnotations()).toTypedArray()
+}
+
+inline fun <reified T : Annotation> KProperty<*>.findFieldAnnotations(): Set<T> {
+    return javaField?.getAnnotationsByType(T::class.java)?.toSet() ?: emptySet()
+}
+
+inline fun <reified T : Annotation> KProperty<*>.findGetterAnnotations(): Set<T> {
+    return getter.annotations.filterIsInstance<T>().toSet()
+}
+
+inline fun <reified T : Annotation> KProperty<*>.findSetterAnnotations(): Set<T> {
+    return (this as? KMutableProperty)?.setter?.annotations?.filterIsInstance<T>()?.toSet() ?: emptySet()
+}

--- a/src/test/kotlin/com/github/jntakpe/restdocs/dsl/ByPropertySpec.kt
+++ b/src/test/kotlin/com/github/jntakpe/restdocs/dsl/ByPropertySpec.kt
@@ -1,0 +1,318 @@
+package com.github.jntakpe.restdocs.dsl
+
+import com.fasterxml.jackson.annotation.JsonView
+import com.github.jntakpe.restdocs.dsl.Field.Companion.VIEWS_ATTR
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.JsonFieldType.*
+import java.time.Duration
+
+interface Owner
+interface Merchant
+
+object ByPropertySpec : Spek({
+    describe("Any payload") {
+        context("with simple fields") {
+            it("should create text fields") {
+                data class Pet(val name: String)
+
+                val nameDesc = "Pet's name"
+                val petDoc by obj {
+                    field(Pet::name, nameDesc)
+                }
+                val petDesc = petDoc.find { it.path == Pet::name.name }!!
+                assertThat(petDesc.description).isEqualTo(nameDesc)
+                assertThat(petDesc.isOptional).isFalse()
+                assertThat(petDesc.viewAttr()).isNull()
+                assertThat(petDesc.type).isEqualTo(STRING)
+            }
+            it("should create optional text fields") {
+                data class Pet(val name: String?)
+
+                val petDoc by obj { field(Pet::name, "") }
+                val petDesc = petDoc.find { it.path == Pet::name.name }!!
+                assertThat(petDesc.isOptional).isTrue()
+                assertThat(petDesc.type).isEqualTo(STRING)
+            }
+            it("should create boolean fields") {
+                data class Pet(val alive: Boolean)
+
+                val aliveDesc = "is Pet alive"
+                val petDoc by obj {
+                    field(Pet::alive, aliveDesc)
+                }
+                val petDesc = petDoc.find { it.path == Pet::alive.name }!!
+                assertThat(petDesc.description).isEqualTo(aliveDesc)
+                assertThat(petDesc.isOptional).isFalse()
+                assertThat(petDesc.viewAttr()).isNull()
+                assertThat(petDesc.type).isEqualTo(BOOLEAN)
+            }
+            it("should create optional boolean fields") {
+                data class Pet(val alive: Boolean?)
+
+                val aliveDesc = "is Pet alive"
+                val petDoc by obj {
+                    field(Pet::alive, aliveDesc)
+                }
+                val petDesc = petDoc.find { it.path == Pet::alive.name }!!
+                assertThat(petDesc.isOptional).isTrue()
+                assertThat(petDesc.type).isEqualTo(BOOLEAN)
+            }
+            it("should create number fields") {
+                data class Pet(
+                    val ageShort: Short,
+                    val ageInt: Int,
+                    val ageLong: Long,
+                    val ageFloat: Float,
+                    val ageDouble: Double
+                )
+
+                val ageDesc = "Pet's age"
+                val petDoc by obj {
+                    field(Pet::ageShort, ageDesc)
+                    field(Pet::ageInt, ageDesc)
+                    field(Pet::ageLong, ageDesc)
+                    field(Pet::ageFloat, ageDesc)
+                    field(Pet::ageDouble, ageDesc)
+                }
+                assertThat(petDoc.map { it.description }).containsOnly(ageDesc)
+                assertThat(petDoc.map { it.isOptional }).containsOnly(false)
+                assertThat(petDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petDoc.map { it.type }).containsOnly(NUMBER)
+                assertThat(petDoc.map { it.path }).containsExactly(
+                    Pet::ageShort.name,
+                    Pet::ageInt.name,
+                    Pet::ageLong.name,
+                    Pet::ageFloat.name,
+                    Pet::ageDouble.name
+                )
+            }
+            it("should create optional number fields") {
+                data class Pet(
+                    val ageShort: Short?,
+                    val ageInt: Int?,
+                    val ageLong: Long?,
+                    val ageFloat: Float?,
+                    val ageDouble: Double?
+                )
+
+                val petDoc by obj {
+                    field(Pet::ageShort, "")
+                    field(Pet::ageInt, "")
+                    field(Pet::ageLong, "")
+                    field(Pet::ageFloat, "")
+                    field(Pet::ageDouble, "")
+                }
+                assertThat(petDoc.map { it.isOptional }).containsOnly(true)
+            }
+            it("should create nil fields") {
+                data class Pet(val name: String? = null)
+
+                val nameDesc = "Pet's name, always null"
+                val petDoc by obj {
+                    nil(Pet::name, nameDesc)
+                }
+                val petDesc = petDoc.find { it.path == Pet::name.name }!!
+                assertThat(petDesc.description).isEqualTo(nameDesc)
+                assertThat(petDesc.isOptional).isFalse()
+                assertThat(petDesc.viewAttr()).isNull()
+                assertThat(petDesc.type).isEqualTo(NULL)
+            }
+            it("should create varies fields") {
+                data class Pet(val avatar: Any, val food: Any?)
+
+                val avatarDesc = "Pet's avatar"
+                val foodDesc = "Pet's favorite food"
+                val petDoc by obj {
+                    field(Pet::avatar, avatarDesc)
+                    field(Pet::food, foodDesc)
+                }
+                assertThat(petDoc.map { it.description }).containsExactly(avatarDesc, foodDesc)
+                assertThat(petDoc.map { it.isOptional }).containsExactly(false, true)
+                assertThat(petDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petDoc.map { it.type }).containsOnly(VARIES)
+                assertThat(petDoc.map { it.path }).containsExactly(Pet::avatar.name, Pet::food.name)
+            }
+            it("should infer json views") {
+                data class Pet(
+                    val noView: String,
+                    @field:JsonView(value = [Owner::class]) val oneView: String,
+                    @field:JsonView(value = [Owner::class, Merchant::class]) val twoView: String
+                )
+
+                val petDoc by obj {
+                    field(Pet::noView, "")
+                    field(Pet::oneView, "")
+                    field(Pet::twoView, "")
+                }
+                assertThat(petDoc.map { it.viewAttr() }).containsExactly(
+                    null,
+                    mutableSetOf(Owner::class),
+                    mutableSetOf(Owner::class, Merchant::class)
+                )
+            }
+            it("should infer json views on getters/steers") {
+                data class Pet(
+                    @get:JsonView(value = [Owner::class]) val getterView: String,
+                    @set:JsonView(value = [Owner::class]) var setterView: String
+                )
+
+                val petDoc by obj {
+                    field(Pet::getterView, "")
+                    field(Pet::setterView, "")
+                }
+                assertThat(petDoc.map { it.viewAttr() }).containsOnly(mutableSetOf(Owner::class))
+            }
+            it("should allow forcing type") {
+                data class Pet(val ttl: Duration, val ttd: Duration?)
+
+                val ttlDesc = "Pet's time to live"
+                val ttdDesc = "Pet's time to death"
+                val petDoc by obj {
+                    field<String>(Pet::ttl, ttlDesc)
+                    field<String?>(Pet::ttd, ttdDesc)
+                }
+                assertThat(petDoc.map { it.description }).containsExactly(ttlDesc, ttdDesc)
+                assertThat(petDoc.map { it.path }).containsExactly(Pet::ttl.name, Pet::ttd.name)
+                assertThat(petDoc.map { it.isOptional }).containsExactly(false, true)
+                assertThat(petDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petDoc.map { it.type }).containsOnly(STRING)
+            }
+        }
+        context("with complex fields") {
+            it("should create simple array fields") {
+                data class Pet(
+                    val nicknamesList: List<String>,
+                    val nicknamesSet: Set<String>,
+                    val nicknamesCollection: Collection<String>
+                )
+
+                val nicknamesDesc = "Pet's nicknames"
+                val petDoc by obj {
+                    field(Pet::nicknamesList, nicknamesDesc)
+                    field(Pet::nicknamesSet, nicknamesDesc)
+                    field(Pet::nicknamesCollection, nicknamesDesc)
+                }
+                assertThat(petDoc.map { it.description }).containsOnly(nicknamesDesc)
+                assertThat(petDoc.map { it.isOptional }).containsOnly(false)
+                assertThat(petDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petDoc.map { it.type }).containsOnly(ARRAY)
+                assertThat(petDoc.map { it.path }).containsExactly(
+                    Pet::nicknamesList.name,
+                    Pet::nicknamesSet.name,
+                    Pet::nicknamesCollection.name
+                )
+            }
+            it("should create optional simple array fields") {
+                data class Pet(
+                    val nicknamesList: List<String>?,
+                    val nicknamesSet: Set<String>?,
+                    val nicknamesCollection: Collection<String>?
+                )
+
+                val petDoc by obj {
+                    field(Pet::nicknamesList, "")
+                    field(Pet::nicknamesSet, "")
+                    field(Pet::nicknamesCollection, "")
+                }
+                assertThat(petDoc.map { it.isOptional }).containsOnly(true)
+            }
+            it("should create array fields") {
+                data class Store(val location: String)
+                data class Pet(
+                    val storesList: List<Store>,
+                    val storesSet: Set<Store>,
+                    val storesCollection: Collection<Store>
+                )
+
+                val storesDesc = "Pet's stores"
+                val locationDesc = "Store GPS coordinates"
+                val storeDoc by obj {
+                    field(Store::location, locationDesc)
+                }
+                val petDoc by obj {
+                    field(Pet::storesList, storesDesc, storeDoc)
+                    field(Pet::storesSet, storesDesc, storeDoc)
+                    field(Pet::storesCollection, storesDesc, storeDoc)
+                }
+                assertThat(petDoc.map { it.isOptional }).containsOnly(false)
+                assertThat(petDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petDoc.map { it.type }).containsExactly(
+                    ARRAY, STRING,
+                    ARRAY, STRING,
+                    ARRAY, STRING
+                )
+                assertThat(petDoc.map { it.path }).containsExactly(
+                    Pet::storesList.name,
+                    "${Pet::storesList.name}[].${Store::location.name}",
+                    Pet::storesSet.name,
+                    "${Pet::storesSet.name}[].${Store::location.name}",
+                    Pet::storesCollection.name,
+                    "${Pet::storesCollection.name}[].${Store::location.name}"
+                )
+                assertThat(petDoc.map { it.description }).containsExactly(
+                    storesDesc, locationDesc,
+                    storesDesc, locationDesc,
+                    storesDesc, locationDesc
+                )
+            }
+            it("should create object fields") {
+                data class Location(val lat: String, val lon: String)
+                data class Store(val location: Location)
+                data class Pet(val store: Store)
+
+                val storeDesc = "Pet's store"
+                val locationDesc = "Store GPS coordinates"
+                val latDesc = "Latitude"
+                val lonDesc = "Longitude"
+                val locationDoc by obj {
+                    field(Location::lat, latDesc)
+                    field(Location::lon, lonDesc)
+                }
+                val storeDoc by obj {
+                    field(Store::location, locationDesc, locationDoc)
+                }
+                val petDoc by obj {
+                    field(Pet::store, storeDesc, storeDoc)
+                }
+                assertThat(petDoc.map { it.isOptional }).containsOnly(false)
+                assertThat(petDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petDoc.map { it.type }).containsExactly(
+                    OBJECT,
+                    OBJECT,
+                    STRING, STRING
+                )
+                assertThat(petDoc.map { it.path }).containsExactly(
+                    Pet::store.name,
+                    "${Pet::store.name}.${Store::location.name}",
+                    "${Pet::store.name}.${Store::location.name}.${Location::lat.name}",
+                    "${Pet::store.name}.${Store::location.name}.${Location::lon.name}"
+                )
+                assertThat(petDoc.map { it.description }).containsExactly(
+                    storeDesc,
+                    locationDesc,
+                    latDesc,
+                    lonDesc
+                )
+            }
+            it("should create array of objects") {
+                data class Pet(val name: String)
+
+                val nameDesc = "Pet's name"
+                val petDoc by obj { field(Pet::name, nameDesc) }
+                val petsDoc by arr<Pet>(petDoc)
+                val petsDescDoc by arrDesc(petDoc, "Array of cute pets")
+                assertThat(petsDoc.map { it.isOptional }).containsOnly(false)
+                assertThat(petsDoc.map { it.viewAttr() }).containsOnlyNulls()
+                assertThat(petsDoc.map { it.path }).containsExactly("[]", "[].name")
+                assertThat(petsDoc.map { it.type }).containsExactly(ARRAY, STRING)
+                assertThat(petsDoc.map { it.description }).containsExactly("Array of pets", nameDesc)
+                assertThat(petsDescDoc.map { it.description }).containsExactly("Array of cute pets", nameDesc)
+            }
+        }
+    }
+})
+
+fun FieldDescriptor.viewAttr() = attributes[VIEWS_ATTR] as? Views


### PR DESCRIPTION
* Add field method for inferring name, nullability and jsonViews from KProperty
* Add .asReq() & .asResp() helpers
* Add delegates by obj, arr, arrDesc for initializing list of field descriptors into a val

Looks like : 
```kotlin
val answerDesc by obj {
    field(AnswerApiDto::label, "A possible answer to a question")
    field(AnswerApiDto::valid, "True if the answer is the valid one, defaults to false")
}
val questionDesc by obj {
    field(QuestionApiDto::label, "Title of the question")
    field<String>(QuestionApiDto::duration, "Maximum time a user has to answer, defaults to 30 seconds")
    field(QuestionApiDto::answers, "Array containing proposed answers", answerDesc)
}
val quizDesc by obj {
    field(QuizApiDto::id, "Quiz unique identifier")
    field(QuizApiDto::title, "Unique quiz title")
    field<String>(QuizApiDto::duration, "Maximum duration, sum of all questions duration")
    field(QuizApiDto::questions, "Array containing questions", questionDesc)
}
val quizzesDesc by arrDesc(quizDesc, "Array of quizzes")
```